### PR TITLE
Server hypergolix.yml config support; CLI config deprecation

### DIFF
--- a/hypergolix/cli.py
+++ b/hypergolix/cli.py
@@ -115,12 +115,14 @@ server_start_parser.add_argument(
     'pidfile',
     action = 'store',
     type = str,
+    default = None,
+    nargs = '?',
     help = 'The full path to the PID file we should use for the service.'
 )
 server_start_parser.add_argument(
     '--cachedir', '-c',
     action = 'store',
-    required = True,
+    required = False,
     dest = 'cachedir',
     default = None,
     type = str,
@@ -144,7 +146,7 @@ server_start_parser.add_argument(
     '--port', '-p',
     action = 'store',
     dest = 'port',
-    default = 7770,
+    default = None,
     type = int,
     help = 'Specify the TCP port to use. Defaults to 7770.'
 )
@@ -167,11 +169,13 @@ server_start_parser.add_argument(
 )
 server_start_parser.add_argument(
     '--debug',
+    default = None,
     action = 'store_true',
     help = 'Enable debug mode. Sets verbosity to debug unless overridden.'
 )
 server_start_parser.add_argument(
     '--traceur',
+    default = None,
     action = 'store_true',
     help = 'Enable thorough analysis, including stack tracing. '
            'Implies verbosity of debug.'
@@ -215,6 +219,8 @@ server_stop_parser.add_argument(
     'pidfile',
     action = 'store',
     type = str,
+    default = None,
+    nargs = '?',
     help = 'The full path to the PID file we should use for the service.'
 )
 

--- a/hypergolix/config.py
+++ b/hypergolix/config.py
@@ -38,6 +38,7 @@ import webbrowser
 import yaml
 import inspect
 import os
+import warnings
 
 from golix import Ghid
 from golix import Secret
@@ -724,6 +725,9 @@ def _exclusive_named_remote(remote):
 
 def _handle_verbosity(config, verbosity):
     if verbosity is not None:
+        warnings.warn('Modifying Hypergolix configuration through CLI is ' +
+                      'deprecated. Please edit the hypergolix.yml config ' +
+                      'file instead.', DeprecationWarning, stacklevel=10)
         lookup = {
             'extreme': 'extreme',
             'shouty': 'shouty',
@@ -745,16 +749,26 @@ def _handle_debug(config, debug_enabled):
     if debug_enabled is None:
         return
         
-    elif debug_enabled:
-        config.instrumentation.debug = True
-        
     else:
-        config.instrumentation.debug = False
+        warnings.warn('Modifying Hypergolix configuration through CLI is ' +
+                      'deprecated. Please edit the hypergolix.yml config ' +
+                      'file instead.', DeprecationWarning, stacklevel=10)
+        
+        if debug_enabled:
+            config.instrumentation.debug = True
+        
+        else:
+            config.instrumentation.debug = False
 
 
 def _handle_remotes(config, only_remotes, add_remotes, remove_remotes):
     ''' Manages remotes.
     '''
+    if ((only_remotes is not None) | bool(add_remotes) | bool(remove_remotes)):
+        warnings.warn('Modifying Hypergolix configuration through CLI is ' +
+                      'deprecated. Please edit the hypergolix.yml config ' +
+                      'file instead.', DeprecationWarning, stacklevel=10)
+    
     # Handling an exclusive remote declaration
     if only_remotes is not None:
         # Remove all existing remotes
@@ -863,6 +877,9 @@ def _handle_ipc(config, ipc):
     ''' If IPC is defined, update it.
     '''
     if ipc is not None:
+        warnings.warn('Modifying Hypergolix configuration through CLI is ' +
+                      'deprecated. Please edit the hypergolix.yml config ' +
+                      'file instead.', DeprecationWarning, stacklevel=10)
         config.process.ipc_port = ipc
 
 
@@ -962,6 +979,9 @@ def handle_args(args):
             config = Config(cfg_path)
     
     with config:
+        # Make sure we actually show the warnings; deprecation is normally
+        # ignored.
+        warnings.simplefilter('module')
         _handle_remotes(
             config,
             args.only_remotes,

--- a/hypergolix/config.py
+++ b/hypergolix/config.py
@@ -439,6 +439,16 @@ class Process(metaclass=_AutoMapper):
     ipc_port = AutoField()
     
     
+class Server(metaclass=_AutoMapper):
+    ghidcache = AutoField(decode=pathlib.Path, encode=str)
+    logdir = AutoField(decode=pathlib.Path, encode=str)
+    pid_file = AutoField(decode=pathlib.Path, encode=str)
+    host = AutoField()
+    port = AutoField()
+    verbosity = AutoField()
+    debug = AutoField()
+    
+    
 class Config(metaclass=_AutoMapper):
     ''' Context handler for semi-atomic config updates.
     
@@ -459,6 +469,7 @@ class Config(metaclass=_AutoMapper):
     instrumentation = AutoField(Instrumentation)
     user = AutoField(User)
     remotes = AutoField(Remote, listed=True)
+    server = AutoField(Server)
     
     TARGET_FNAME = 'hypergolix.yml'
     OLD_FNAMES = {'hgx-cfg.json'}
@@ -482,6 +493,12 @@ class Config(metaclass=_AutoMapper):
                 'logdir': root / 'logs',
                 'pid_file': root / 'hypergolix.pid',
                 'ipc_port': 7772
+            },
+            'server': {
+                'ghidcache': root / 'ghidcache',
+                'logdir': root / 'logs',
+                'pid_file': root / 'hgx-server.pid',
+                'port': 7770
             }
         }
     

--- a/hypergolix/service.py
+++ b/hypergolix/service.py
@@ -38,7 +38,6 @@ import logging
 import loopa
 import concurrent.futures
 import socket
-import pathlib
 import threading
 import http.server
 from http import HTTPStatus
@@ -61,7 +60,6 @@ from hypergolix.persistence import Bookie
 
 from hypergolix.lawyer import LawyerCore
 from hypergolix.undertaker import UndertakerCore
-from hypergolix.librarian import LibrarianCore
 from hypergolix.librarian import DiskLibrarian
 from hypergolix.postal import PostOffice
 from hypergolix.remotes import Salmonator

--- a/hypergolix/service.py
+++ b/hypergolix/service.py
@@ -241,7 +241,7 @@ class RemotePersistenceServer(loopa.TaskCommander):
 def start(namespace=None):
     ''' Starts a Hypergolix daemon.
     '''
-    # Command args coming in.
+    # Command arg support is deprecated.
     if namespace is not None:
         # Gigantic error trap
         if ((namespace.host is not None) | (namespace.port is not None) |

--- a/hypergolix/service.py
+++ b/hypergolix/service.py
@@ -67,6 +67,10 @@ from hypergolix.postal import PostOffice
 from hypergolix.remotes import Salmonator
 from hypergolix.remotes import RemotePersistenceProtocol
 
+from hypergolix.config import Config
+from hypergolix.utils import _ensure_dir_exists
+from hypergolix.utils import _default_to
+
 
 # ###############################################
 # Boilerplate
@@ -241,52 +245,35 @@ def start(namespace=None):
     '''
     # Command args coming in.
     if namespace is not None:
-        host = namespace.host
-        port = namespace.port
-        debug = namespace.debug
-        traceur = namespace.traceur
-        chdir = namespace.chdir
-        # Convert log dir to absolute if defined
-        if namespace.logdir is not None:
-            log_dir = str(pathlib.Path(namespace.logdir).absolute())
-        else:
-            log_dir = namespace.logdir
-        # Convert cache dir to absolute if defined
-        if namespace.cachedir is not None:
-            cache_dir = str(pathlib.Path(namespace.cachedir).absolute())
-        else:
-            cache_dir = namespace.cachedir
-        verbosity = namespace.verbosity
-        # Convert pid path to absolute (must be defined)
-        pid_path = str(pathlib.Path(namespace.pidfile).absolute())
-        
-    # Daemonizing, we still need these to be defined to avoid NameErrors
-    else:
-        host = None
-        port = None
-        debug = None
-        traceur = None
-        chdir = None
-        log_dir = None
-        cache_dir = None
-        verbosity = None
-        pid_path = None
+        # Gigantic error trap
+        if ((namespace.host is not None) | (namespace.port is not None) |
+            (namespace.debug is not None) | (namespace.traceur is not None) |
+            (namespace.pidfile is not None) | (namespace.logdir is not None) |
+            (namespace.cachedir is not None) | (namespace.chdir is not None) |
+            (namespace.verbosity is not None)):
+                raise RuntimeError('Server configuration through CLI is no ' +
+                                   'longer supported. Edit hypergolix.yml ' +
+                                   'configuration file instead.')
     
     with Daemonizer() as (is_setup, daemonizer):
-        # Daemonize. Don't strip cmd-line arguments, or we won't know to
-        # continue with startup
-        (is_parent, host, port, debug, traceur, log_dir, cache_dir, verbosity,
-         pid_path) = daemonizer(
-            pid_path,
-            host,
-            port,
-            debug,
-            traceur,
-            log_dir,
-            cache_dir,
-            verbosity,
-            pid_path,
-            chdir = chdir,
+        # Get our config path in setup, so that we error out before attempting
+        # to daemonize (if anything is wrong).
+        if is_setup:
+            config = Config.find()
+            config_path = config.path
+            chdir = config_path.parent
+            pid_file = config.server.pid_file
+            
+        else:
+            config_path = None
+            pid_file = None
+            chdir = None
+        
+        # Daemonize.
+        is_parent, config_path = daemonizer(
+            str(pid_file),
+            config_path,
+            chdir = str(chdir),
             explicit_rescript = '-m hypergolix.service'
         )
         
@@ -294,22 +281,26 @@ def start(namespace=None):
         # PARENT EXITS HERE #
         #####################
         
-    verbosity = _cast_verbosity(verbosity, debug, traceur)
-        
-    if log_dir is not None:
-        logutils.autoconfig(
-            tofile = True,
-            logdirname = log_dir,
-            logname = 'hgxremote',
-            loglevel = verbosity
-        )
+    config = Config.load(config_path)
+    _ensure_dir_exists(config.server.ghidcache)
+    _ensure_dir_exists(config.server.logdir)
+    
+    debug = _default_to(config.server.debug, False)
+    verbosity = _default_to(config.server.verbosity, 'info')
+    
+    logutils.autoconfig(
+        tofile = True,
+        logdirname = config.server.logdir,
+        logname = 'hgxserver',
+        loglevel = verbosity
+    )
         
     logger.debug('Parsing config...')
-    host = _cast_host(host)
+    host = _cast_host(config.server.host)
     rps = RemotePersistenceServer(
-        cache_dir,
+        config.server.ghidcache,
         host,
-        port,
+        config.server.port,
         reusable_loop = False,
         threaded = False,
         debug = debug
@@ -330,7 +321,7 @@ def start(namespace=None):
     # Normally I'd do this within daemonization, but in this case, we need to
     # wait to have access to the handler.
     sighandler = SignalHandler1(
-        pid_path,
+        str(config.server.pid_file),
         sigint = signal_handler,
         sigterm = signal_handler,
         sigabrt = signal_handler
@@ -344,7 +335,13 @@ def start(namespace=None):
 def stop(namespace=None):
     ''' Stops the Hypergolix daemon.
     '''
-    daemoniker.send(namespace.pidfile, SIGTERM)
+    if namespace.pidfile is not None:
+        raise RuntimeError('Server pidfile specification through CLI is no ' +
+                           'longer supported. Edit hypergolix.yml ' +
+                           'configuration file instead.')
+        
+    config = Config.find()
+    daemoniker.send(str(config.server.pid_file), SIGTERM)
     
     
 if __name__ == "__main__":

--- a/tests/trashtest/test_config.py
+++ b/tests/trashtest/test_config.py
@@ -171,6 +171,14 @@ remotes:
 - host: foo
   port: 1234
   tls: false
+server:
+  ghidcache: null
+  logdir: null
+  pid_file: null
+  host: null
+  port: null
+  verbosity: null
+  debug: null
 '''
 
 


### PR DESCRIPTION
Hypergolix servers can now be configured through hypergolix.yml. See #16 .

All mutating CLI configuration is deprecated or removed. See #14 .